### PR TITLE
support SBref and dat directory

### DIFF
--- a/xa30_workaround/scripts/dcmdat2niix.py
+++ b/xa30_workaround/scripts/dcmdat2niix.py
@@ -32,7 +32,7 @@ def main():
     parser.add_argument("-h", "--help", action="store_true")
     parser.add_argument(
         "--dat-dir",
-        help="Directory containing DAT files. If not specified, look in the same directory as DICOM files by default. Note that each dat file should have (in the filename, the same Series Instance UID as the DICOM file it is associated with).",
+        help="Directory containing DAT files. If not specified, look in the same directory as DICOM files by default. Note that each dat file should have, in the filename, the same Series Instance UID as the DICOM file it is associated with.",
         type=dir_path,
         dest="dat_dir",
         default="",

--- a/xa30_workaround/scripts/dcmdat2niix.py
+++ b/xa30_workaround/scripts/dcmdat2niix.py
@@ -5,7 +5,7 @@ import shutil
 from pathlib import Path
 import argparse
 import numpy as np
-import nibabel as nib
+from nibabel.nifti1 import Nifti1Image
 import os
 import pydicom
 from xa30_workaround.dicom import dicom2nifti
@@ -32,7 +32,7 @@ def main():
     parser.add_argument("-h", "--help", action="store_true")
     parser.add_argument(
         "--dat-dir",
-        help="Directory containing DAT files. If not specified, look in the same directory as DICOM files by default.",
+        help="Directory containing DAT files. If not specified, look in the same directory as DICOM files by default. Note that each dat file should have (in the filename, the same Series Instance UID as the DICOM file it is associated with).",
         type=dir_path,
         dest="dat_dir",
         default="",
@@ -92,6 +92,10 @@ def main():
                     diff = TEs[1:] - TEs[0:-1]
                     TEs = np.insert(TEs[1:][diff > 0], 0, TEs[0])
                     break
+        
+        # if TEs is None, then we could not find the alTE tag and should raise an error
+        if TEs is None:
+            raise ValueError(f"Could not find alTE tag in {dicom}.")
 
         # load the json file of the nifti
         nifti_json = Path(nifti).with_suffix(".json")
@@ -108,7 +112,7 @@ def main():
             suffix = ".nii.gz"
             if not nifti_img_path.exists():
                 raise ValueError(f"Could not find nifti file {nifti_img_path}.")
-        nifti_img = nib.load(nifti_img_path)
+        nifti_img = Nifti1Image.load(nifti_img_path)
 
         # get the shape of the nifti file
         # we want the first dimension to me the number of echos
@@ -139,7 +143,7 @@ def main():
             # strip off the last six characters, the .0.0.0 part
             # should then look something like
             # 1.3.12.2.1107.5.2.43.166158.2023072109355378899049069
-            dicom_sid = pydicom.dcmread(dicom)[0x0020, 0x000e].value[:-6]
+            dicom_sid = pydicom.dcmread(dicom)[0x0020, 0x000E].value[:-6]
             print(dicom_sid)
 
             # look for .dat files in dat_dir whose name contains the sid
@@ -155,30 +159,29 @@ def main():
         print(f"Found {len(dat_files)} .dat files associated with {dicom}.")
         print("Converting .dat files to nifti...")
         data_array = dat_to_array(dat_files, rshape)
-
+        
         # check if number of frames in nifti matches number of frames in .dat files
-        if len(shape) <= 3:
-            # There is only one frame (time point) in the nifti.
-            if data_array.shape[-1] > 1:
-                raise ValueError(f"There is one frame in nifti but {data_array.shape[-1]} frames in the .dat files.")
-            data_array = np.squeeze(data_array)
-        else:
-            if data_array.shape[-1] != shape[-1]:
-                raise ValueError(f"The number of frames in the .dat files, {data_array.shape[-1]} does not match the number of frames in the nifti, {shape[-1]}.")
+        if len(shape) <= 3 and data_array.shape[-1] > 1:
+            raise ValueError(f"There is one frame in nifti but {data_array.shape[-1]} frames in the .dat files.")
+        elif data_array.shape[-1] != shape[-1]:  # type: ignore
+            raise ValueError(
+                f"The number of frames in the .dat files, {data_array.shape[-1]} does not match the number of frames in the nifti, {shape[-1]}."  # type: ignore
+            )
+        data_array = np.squeeze(data_array)
 
         # do first echo, first frame sanity check
-        if len(shape) <= 3:
-            # There is only one frame (time point).
-            if not np.all(np.isclose(normalize(data_array[..., 0].astype("f8")), normalize(nifti_img.dataobj))):
-                raise ValueError(
-                    "Sanity check failed. The first echo, first frame of the .dat files does not match the nifti."
-                )
-        else:
-            # Compare the first frames.
-            if not np.all(np.isclose(normalize(data_array[..., 0, 0].astype("f8")), normalize(nifti_img.dataobj[..., 0]))):
-                raise ValueError(
-                    "Sanity check failed. The first echo, first frame of the .dat files does not match the nifti."
-                )
+        if len(shape) <= 3 and not np.all(
+            np.isclose(normalize(data_array[..., 0].astype("f8")), normalize(nifti_img.dataobj))
+        ):
+            raise ValueError(
+                "Sanity check failed. The first echo, first frame of the .dat files does not match the nifti."
+            )
+        elif not np.all(
+            np.isclose(normalize(data_array[..., 0, 0].astype("f8")), normalize(nifti_img.dataobj[..., 0]))
+        ):
+            raise ValueError(
+                "Sanity check failed. The first echo, first frame of the .dat files does not match the nifti."
+            )
 
         # loop over each echo skipping the first one
         # only renaming if neccessary
@@ -209,12 +212,12 @@ def main():
                 if "_ph" in nifti.name:
                     if len(shape) <= 3:
                         # there is only one frame (time point)
-                        nib.Nifti1Image(data_array[..., 0], nifti_img.affine, nifti_img.header).to_filename(
+                        Nifti1Image(data_array[..., 0], nifti_img.affine, nifti_img.header).to_filename(
                             nifti_img_path
                         )
                     else:
                         # save all frames
-                        nib.Nifti1Image(data_array[..., 0, :], nifti_img.affine, nifti_img.header).to_filename(
+                        Nifti1Image(data_array[..., 0, :], nifti_img.affine, nifti_img.header).to_filename(
                             nifti_img_path
                         )
                 continue
@@ -230,10 +233,10 @@ def main():
             output_path = output_base.with_suffix(suffix)
             if len(shape) <= 3:
                 # there is only one frame (time point)
-                nib.Nifti1Image(data_array[..., i], nifti_img.affine, nifti_img.header).to_filename(output_path)
+                Nifti1Image(data_array[..., i], nifti_img.affine, nifti_img.header).to_filename(output_path)
             else:
                 # save all frames
-                nib.Nifti1Image(data_array[..., i, :], nifti_img.affine, nifti_img.header).to_filename(output_path)
+                Nifti1Image(data_array[..., i, :], nifti_img.affine, nifti_img.header).to_filename(output_path)
             # save the json file
             output_json = output_path.with_suffix(".json")
             with open(output_json, "w") as f:


### PR DESCRIPTION
@vanandrew, please consider reviewing this pair of commits that adapt the `dcmdat2niix` script to my lab's workflow.  It adds:

1. Support for multi-echo volumes with a single time point, e.g. single-band reference images.
2. Support for finding `*.dat` files in a separate directory and matching them up with the right nifti.  One of our research assistants thought this would be a good way to organize the `*.dat` files.  🤷

Happy to split these out into separate PRs.  These work on my data, but I have not made any effort to test on other people's data.